### PR TITLE
Net::SSH requires extra gems to connect to modern hosts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 gem 'colored'
 gem 'net-ssh'
+gem 'ed25519'
+gem 'bcrypt_pbkdf'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,19 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    bcrypt_pbkdf (1.1.0)
     colored (1.2)
+    ed25519 (1.2.4)
     net-ssh (6.1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt_pbkdf
   colored
+  ed25519
   net-ssh
 
 BUNDLED WITH
-   2.1.4
+   2.2.22


### PR DESCRIPTION
It dies with the following error:

```
lib/net/ssh/authentication/ed25519_loader.rb:21:in `raiseUnlessLoaded': unsupported key type `ssh-ed25519' (NotImplementedError)
net-ssh requires the following gems for ed25519 support:
* ed25519 (>= 1.2, < 2.0)
* bcrypt_pbkdf (>= 1.0, < 2.0)
See https://github.com/net-ssh/net-ssh/issues/565 for more information
```