### PR TITLE
Maximise use of the worker batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,14 @@ Usage:
 
 Example output:
 ```console
-[Batch 1/1] puppet01 to puppet04
+[P:3 W:1 D:0] Worker 1: Processing puppet01....
+[P:2 W:2 D:0] Worker 3: Processing puppet02....
+[P:1 W:3 D:0] Worker 2: Processing puppet03....
+[P:0 W:4 D:0] Worker 4: Processing puppet04....
+[P:0 W:3 D:1] Worker 4: Done after processing 1 hosts.
+[P:0 W:2 D:2] Worker 1: Done after processing 1 hosts.
+[P:0 W:1 D:3] Worker 2: Done after processing 1 hosts.
+[P:0 W:0 D:4] Worker 3: Done after processing 1 hosts.
 [Case 1/6] puppet01 puppet02 puppet03 puppet04
 [notice] Class[Telegraf::Service]: Unscheduling all events on Class[Telegraf::Service]
 [notice] /Stage[main]/Jnx_puppet::Server/File[/etc/sysconfig/puppetserver]/content:

--- a/puppet-ssh
+++ b/puppet-ssh
@@ -14,6 +14,7 @@ options = OpenStruct.new
 PUPPET = '/opt/puppetlabs/bin/puppet'
 
 options.batch = 10
+options.bar = false
 options.user = ENV['USER']
 additional_options = []
 
@@ -41,6 +42,9 @@ OptionParser.new do |opts|
   end
   opts.on('-s source', '--source source', String, 'A regex to select only certain resources') do |s|
     options.source = s
+  end
+  opts.on('--[no-]bar', TrueClass, 'Show progress with a bar graph instead of exact numbers') do |s|
+    options.bar = s
   end
   opts.on_tail('-h', '--help') do
     puts opts
@@ -101,8 +105,21 @@ threads = []
   done: 0,
 }
 
-def progress_string
-  "[P:%d W:%d D:%d]" % [ @progress[:pending], @progress[:wip], @progress[:done] ]
+@symbols = {
+  pending: ?-,
+  wip: ?+,
+  done: ?#,
+}
+
+
+def progress_string(bar)
+  if bar then
+    [ :done, :wip, :pending ].reduce("") { |string, state|
+      string << @symbols[state] * @progress[state]
+    }
+  else
+    "[P:%d W:%d D:%d]" % [ @progress[:pending], @progress[:wip], @progress[:done] ]
+  end
 end
 
 [ options.batch, hosts.size ].min.times { |thread_counter|
@@ -123,7 +140,7 @@ end
           Thread.current[:done] += 1
           @progress[:pending] -= 1
           @progress[:wip] += 1
-          puts "#{progress_string} Worker #{Thread.current[:index]}: Processing #{Thread.current[:host]}..."
+          puts "#{progress_string(options.bar)} Worker #{Thread.current[:index]}: Processing #{Thread.current[:host]}..."
         }
 
         Net::SSH.start(Thread.current[:host], options.user, ssh_options) do |ssh|
@@ -178,7 +195,7 @@ while threads.size > 0 do
   mutex.synchronize {
     threads.each_with_index { |t, index|
       unless t.alive? then
-        puts "#{progress_string} Worker #{t[:index]}: Done after processing #{t[:done]} hosts."
+        puts "#{progress_string(options.bar)} Worker #{t[:index]}: Done after processing #{t[:done]} hosts."
         t.join
         threads.delete_at(index)
       end

--- a/puppet-ssh
+++ b/puppet-ssh
@@ -91,52 +91,84 @@ aggregates = {}
 
 ssh_options = {verify_host_key: :never, non_interactive: true, check_host_ip: false}
 
-batches = hosts.each_slice(options.batch).to_a
-batches.each.with_index(1) do |batch, index|
-  puts "[Batch #{index}/#{batches.size}] #{batch[0]} to #{batch[-1]}"
-  threads = []
-  batch.each do |host|
-    threads << Thread.new do
-      Net::SSH.start(host, options.user, ssh_options) do |ssh|
-        tmpdir = ssh.exec!('/usr/bin/mktemp -d').chomp
-        logoutput = "#{tmpdir}/output.json"
-        ssh.exec!("sudo #{PUPPET} agent --test --noop --logdest #{logoutput} #{additional_options.join(' ')}")
-        ssh.loop
-        output = ssh.exec!("cat #{logoutput}")
-        json = JSON.parse(output + ']')
-        Thread.current[:host] = host
-        Thread.current[:json] = json
+mutex = Mutex.new
+
+threads = []
+
+[ options.batch, hosts.size ].min.times { |thread_counter|
+
+  threads << Thread.new do
+    mutex.synchronize {
+      Thread.current[:index] = thread_counter + 1
+      Thread.current[:done] = 0
+    }
+
+    catch :done do
+
+      loop {
+
+        mutex.synchronize {
+          throw :done if hosts.size == 0
+          Thread.current[:host] = hosts.shift
+          Thread.current[:done] += 1
+          puts "Worker #{Thread.current[:index]}: Processing #{host}..."
+        }
+
+        Net::SSH.start(Thread.current[:host], options.user, ssh_options) do |ssh|
+          tmpdir = ssh.exec!('/usr/bin/mktemp -d').chomp
+          logoutput = "#{tmpdir}/output.json"
+          ssh.exec!("sudo #{PUPPET} agent --test --noop --logdest #{logoutput} #{additional_options.join(' ')}")
+          ssh.loop
+          output = ssh.exec!("cat #{logoutput}")
+          Thread.current[:json] = JSON.parse(output + ']')
+        end
+
+        mutex.synchronize {
+          Thread.current[:json].each do |entry|
+            message = tarpit(entry['message'])
+
+            # Option to only include some resources matcching a regex
+            next if options.source && entry['source'] !~ /#{options.source}/
+
+            # Non-enssential and a lot of unique messages that make the output less readable
+            next if entry['source'] == 'Puppet' and ['info', 'notice'].include?(entry['level'])
+
+            # Removing pluginsync messages
+            next if entry['source'] =~ %r{^/File}
+
+            aggregates[message] ||= {}
+            aggr = aggregates[message]
+            aggr['hosts'] ||= []
+            aggr['hosts'] << Thread.current[:host]
+            aggr['hosts'] = aggr['hosts'].uniq
+            aggr.merge!({
+              'level'  => entry['level'],
+              'tags'   => entry['tags'],
+              'source' => entry['source'],
+            })
+          end
+        }
+      }
+    end
+
+    Thread.main.wakeup
+
+  end
+
+}
+
+while threads.size > 0 do
+  sleep(60)
+  mutex.synchronize {
+    threads.each_with_index { |t, index|
+      unless t.alive? then
+        puts "Worker #{t[:index]}: Done after processing #{t[:done]} hosts."
+        t.join
+        threads.delete_at(index)
       end
-    end
-  end
-  threads.each do |t|
-    t.join
-    t[:json].each do |entry|
-      message = tarpit(entry['message'])
-
-      # Option to only include some resources matcching a regex
-      next if options.source && entry['source'] !~ /#{options.source}/
-
-      # Non-enssential and a lot of unique messages that make the output less readable
-      next if entry['source'] == 'Puppet' and ['info', 'notice'].include?(entry['level'])
-
-      # Removing pluginsync messages
-      next if entry['source'] =~ %r{^/File}
-
-      aggregates[message] ||= {}
-      aggr = aggregates[message]
-      aggr['hosts'] ||= []
-      aggr['hosts'] << t[:host]
-      aggr['hosts'] = aggr['hosts'].uniq
-      aggr.merge!({
-          'level'  => entry['level'],
-          'tags'   => entry['tags'],
-          'source' => entry['source'],
-      })
-    end
-  end
+    }
+  }
 end
-
 OUTFILE.write('')
 $output = OUTFILE.open('a')
 

--- a/puppet-ssh
+++ b/puppet-ssh
@@ -95,6 +95,16 @@ mutex = Mutex.new
 
 threads = []
 
+@progress = {
+  pending: hosts.size,
+  wip: 0,
+  done: 0,
+}
+
+def progress_string
+  "[P:%d W:%d D:%d]" % [ @progress[:pending], @progress[:wip], @progress[:done] ]
+end
+
 [ options.batch, hosts.size ].min.times { |thread_counter|
 
   threads << Thread.new do
@@ -111,7 +121,9 @@ threads = []
           throw :done if hosts.size == 0
           Thread.current[:host] = hosts.shift
           Thread.current[:done] += 1
-          puts "Worker #{Thread.current[:index]}: Processing #{host}..."
+          @progress[:pending] -= 1
+          @progress[:wip] += 1
+          puts "#{progress_string} Worker #{Thread.current[:index]}: Processing #{Thread.current[:host]}..."
         }
 
         Net::SSH.start(Thread.current[:host], options.user, ssh_options) do |ssh|
@@ -147,6 +159,10 @@ threads = []
               'source' => entry['source'],
             })
           end
+
+          @progress[:wip] -= 1
+          @progress[:done] += 1
+
         }
       }
     end
@@ -162,7 +178,7 @@ while threads.size > 0 do
   mutex.synchronize {
     threads.each_with_index { |t, index|
       unless t.alive? then
-        puts "Worker #{t[:index]}: Done after processing #{t[:done]} hosts."
+        puts "#{progress_string} Worker #{t[:index]}: Done after processing #{t[:done]} hosts."
         t.join
         threads.delete_at(index)
       end


### PR DESCRIPTION
Running the batches in sequence means that each batch has to wait for the slowest host in it before going to the next one. Let's always use the maximum number of workers requested for a faster completion time.