### PR TITLE
Better error handling

### DIFF
--- a/puppet-ssh
+++ b/puppet-ssh
@@ -153,7 +153,9 @@ end
             Thread.current[:json] = JSON.parse(output + ']')
           end
         rescue StandardError => err
-          puts "#{progress_string(options.bar)} Worker #{Thread.current[:index]}: Error processing #{Thread.current[:host]}: #{err}"
+          mutex.synchronize {
+            puts "#{progress_string(options.bar)} Worker #{Thread.current[:index]}: Error processing #{Thread.current[:host]}: #{err}"
+          }
           next
         end
 

--- a/puppet-ssh
+++ b/puppet-ssh
@@ -103,22 +103,24 @@ threads = []
   pending: hosts.size,
   wip: 0,
   done: 0,
+  failed: 0,
 }
 
 @symbols = {
   pending: ?-,
   wip: ?+,
   done: ?#,
+  failed: ?!,
 }
 
 
 def progress_string(bar)
   if bar then
-    [ :done, :wip, :pending ].reduce("") { |string, state|
+    [ :failed, :done, :wip, :pending ].reduce("") { |string, state|
       string << @symbols[state] * @progress[state]
     }
   else
-    "[P:%d W:%d D:%d]" % [ @progress[:pending], @progress[:wip], @progress[:done] ]
+    "[P:%d W:%d D:%d F:%d]" % [ @progress[:pending], @progress[:wip], @progress[:done], @progress[:failed] ]
   end
 end
 
@@ -155,6 +157,8 @@ end
         rescue StandardError => err
           mutex.synchronize {
             puts "#{progress_string(options.bar)} Worker #{Thread.current[:index]}: Error processing #{Thread.current[:host]}: #{err}"
+            @progress[:wip] -= 1
+            @progress[:failed] += 1
           }
           next
         end

--- a/puppet-ssh
+++ b/puppet-ssh
@@ -143,13 +143,18 @@ end
           puts "#{progress_string(options.bar)} Worker #{Thread.current[:index]}: Processing #{Thread.current[:host]}..."
         }
 
-        Net::SSH.start(Thread.current[:host], options.user, ssh_options) do |ssh|
-          tmpdir = ssh.exec!('/usr/bin/mktemp -d').chomp
-          logoutput = "#{tmpdir}/output.json"
-          ssh.exec!("sudo #{PUPPET} agent --test --noop --logdest #{logoutput} #{additional_options.join(' ')}")
-          ssh.loop
-          output = ssh.exec!("cat #{logoutput}")
-          Thread.current[:json] = JSON.parse(output + ']')
+        begin
+          Net::SSH.start(Thread.current[:host], options.user, ssh_options) do |ssh|
+            tmpdir = ssh.exec!('/usr/bin/mktemp -d').chomp
+            logoutput = "#{tmpdir}/output.json"
+            ssh.exec!("sudo #{PUPPET} agent --test --noop --logdest #{logoutput} #{additional_options.join(' ')}")
+            ssh.loop
+            output = ssh.exec!("cat #{logoutput}")
+            Thread.current[:json] = JSON.parse(output + ']')
+          end
+        rescue StandardError => err
+          puts "#{progress_string(options.bar)} Worker #{Thread.current[:index]}: Error processing #{Thread.current[:host]}: #{err}"
+          next
         end
 
         mutex.synchronize {


### PR DESCRIPTION
With this change, we will pass servers that encounter an error while doing SSH.
It could be DNS, connectivity, and that would affect the whole run.
It's much more valuable to pass, and report the error to the user. The current
behavior (the exception) stop the run, and does not report which server caused
the exception.