### PR TITLE
Sort the members so they can be easily identified

### DIFF
--- a/puppet-ssh
+++ b/puppet-ssh
@@ -236,7 +236,7 @@ end
 cases = aggregates.group_by { |_, v| v['hosts'] }
 cases = cases.sort_by { |h, _| h.length }.reverse
 cases.each_with_index do |(h, entries), index|
-  output "[Case #{index + 1}/#{cases.size}] #{h.join(' ')}".black_on_green
+  output "[Case #{index + 1}/#{cases.size}] #{h.sort.join(' ')}".black_on_green
   entries.each do |(message, hash)|
     output format(message, hash)
   end


### PR DESCRIPTION
It is easier to read through a sorted list, as opposed to unsorted.
